### PR TITLE
Update WxPayAPI.cs

### DIFF
--- a/Deepleo.Weixin.SDK/Pay/WxPayAPI.cs
+++ b/Deepleo.Weixin.SDK/Pay/WxPayAPI.cs
@@ -384,6 +384,7 @@ namespace Deepleo.Weixin.SDK.Pay
             foreach (var sA in stringADict.OrderBy(x => x.Key))//参数名ASCII码从小到大排序（字典序）；
             {
                 if (string.IsNullOrEmpty(sA.Value)) continue;//参数的值为空不参与签名；
+                if (string.Compare(sA.Key, "sign", true) == 0) continue;    // 参数中为签名的项，不参加计算
                 sb.Append(sA.Key).Append("=").Append(sA.Value).Append("&");
             }
             var string1 = sb.ToString();


### PR DESCRIPTION
对已包含签名的字典进行计算时，需要忽略掉签名项。
